### PR TITLE
Removing dependency from fabric8-project-bom-full

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -71,10 +71,11 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <fabric8.version>2.2.168</fabric8.version>
+    <assertj.version>2.4.1</assertj.version>
+    <fabric8.version>2.2.169</fabric8.version>
     <rest-assured.version>3.0.0</rest-assured.version>
-    <spring-boot.version>1.3.7.RELEASE</spring-boot.version>
-    <spring-boot-plugin.version>1.3.7.RELEASE</spring-boot-plugin.version>
+    <spring-boot.version>1.4.1.RELEASE</spring-boot.version>
+    <spring-boot-plugin.version>1.4.1.RELEASE</spring-boot-plugin.version>
 
     <maven.compiler.plugin.version>3.1</maven.compiler.plugin.version>
     <maven.enforcer.plugin.version>1.4</maven.enforcer.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -148,18 +148,17 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-project-bom-full</artifactId>
+        <artifactId>fabric8-project-bom-camel-spring-boot</artifactId>
         <version>${fabric8.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${assertj.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
The fabric8-project-bom-full should be removed (see https://issues.jboss.org/browse/OSFUSE-168 for the discussion).

Switching now to fabric8-camel-spring-boot with camel 2.18.0 and spring-boot 1.4.1.RELEASE.